### PR TITLE
Fix the problem that Glob() stops all-work immediately once ioutil.ReadDir fails somewhere

### DIFF
--- a/fastwalk/fastwalk_portable.go
+++ b/fastwalk/fastwalk_portable.go
@@ -18,7 +18,7 @@ import (
 func readDir(dirName string, fn func(dirName, entName string, typ os.FileMode) error) error {
 	fis, err := ioutil.ReadDir(dirName)
 	if err != nil {
-		return err
+		return nil
 	}
 	for _, fi := range fis {
 		if err := fn(dirName, fi.Name(), fi.Mode()&os.ModeType); err != nil {


### PR DESCRIPTION
For #27. 

When ioutils.ReadDir() in fastWalk.FastWalk occurs `Access is denied.`, Glob() stops all-work immediately.
As the result, `Glob("C:\")` can read too few entries.

With this patch, permission errors are ignored on ioutils.ReadDir() and unreadable directories are skipped.