### PR TITLE
support brace sections in patterns without asterisks

### DIFF
--- a/zglob.go
+++ b/zglob.go
@@ -28,7 +28,7 @@ func New(pattern string) (*zenv, error) {
 	globmask := ""
 	root := ""
 	for n, i := range strings.Split(filepath.ToSlash(pattern), "/") {
-		if root == "" && strings.Index(i, "*") != -1 {
+		if root == "" && (strings.Index(i, "*") != -1 || strings.Index(i, "{") != -1) {
 			if globmask == "" {
 				root = "."
 			} else {

--- a/zglob_test.go
+++ b/zglob_test.go
@@ -40,6 +40,7 @@ var testGlobs = []testZGlob{
 	{`./f*`, []string{`foo`}, nil},
 	{`**/bar/**/*.txt`, []string{`foo/bar/baz.txt`, `foo/bar/baz/noo.txt`}, nil},
 	{`**/bar/**/*.{jpg,png}`, []string{`zzz/bar/baz/joo.png`, `zzz/bar/baz/zoo.jpg`}, nil},
+	{`zzz/bar/baz/zoo.{jpg,png}`, []string{`zzz/bar/baz/zoo.jpg`}, nil},
 }
 
 func setup(t *testing.T) string {


### PR DESCRIPTION
When a pattern contains only a brace section but not anything else that needs to be expanded, the direct match path was selected previously..