### PR TITLE
Add err handling in Glob func

### DIFF
--- a/zglob.go
+++ b/zglob.go
@@ -187,7 +187,7 @@ func glob(pattern string, followSymlinks bool) ([]string, error) {
 	relative := !filepath.IsAbs(pattern)
 	matches := []string{}
 
-	fastwalk.FastWalk(zenv.root, func(path string, info os.FileMode) error {
+	err = fastwalk.FastWalk(zenv.root, func(path string, info os.FileMode) error {
 		if zenv.root == "." && len(zenv.root) < len(path) {
 			path = path[len(zenv.root)+1:]
 		}
@@ -228,6 +228,11 @@ func glob(pattern string, followSymlinks bool) ([]string, error) {
 		}
 		return nil
 	})
+
+	if err != nil {
+		return nil, err
+	}
+
 	return matches, nil
 }
 


### PR DESCRIPTION
**Description**
Hi, thanks for developing that lib, it's really helpful! 

But recently I spot one problem and IMO is worth to fix it :)

Currently, the error returned from FastWalk is ignored. This may lead to strange behavior. The path traversing is done in a non-deterministic way if the is more workes, you can end up with a behavior that sometimes the pattern is found and sometimes not as it depends on when it will exit the loop with an error. You as a lib user, you do not know what is the issue because the underlying error is not returned.

This pull request fixes this issue and adds a test to cover that scenario. Unfortunately, I was not able to add it to the common `testGlobs` cases as adding a fixture with wrong permission affects other test cases.